### PR TITLE
Reworked logic for dispatching events

### DIFF
--- a/test/test_events.py
+++ b/test/test_events.py
@@ -26,7 +26,6 @@ def test_basic():
     assert emitted == [True]
     assert "test" in emitter._events
     assert emitter._events["test"] == set([(False, cb)])
-    assert emitter._triggered == []
 
 
 def test_publish_value():


### PR DESCRIPTION
It now uses 2 Prepare handles, one per event type and a single Idle handle to make sure the loop doesn't block.

More info in the commit message :-)
