### PR TITLE
Issue with custom_channels and http handlers

### DIFF
--- a/gaffer/manager.py
+++ b/gaffer/manager.py
@@ -408,6 +408,8 @@ class Manager(object):
             state = self.processes[name]
             info = {"name": state.name, "cmd": state.cmd}
             info.update(state.settings)
+            # remove custom channels because they can't be serialized
+            info.pop('custom_channels', None)
             return info
 
     def get_process_status(self, name):


### PR DESCRIPTION
After my previous pull request an error appear when we try to serialize dictionary returned by `Manager.get_process_info`.

```
Traceback (most recent call last):
  File "/home/blackwithwhite/Work/ged-soa/apps/local/lib/python2.7/site-packages/tornado/web.py", line 1042, in _execute
    getattr(self, self.request.method.lower())(*args, **kwargs)
  File "/home/blackwithwhite/Work/ged-soa/apps/local/lib/python2.7/site-packages/gaffer/http/processes.py", line 161, in get
    self.write(info)
  File "/home/blackwithwhite/Work/ged-soa/apps/local/lib/python2.7/site-packages/tornado/web.py", line 493, in write
    chunk = escape.json_encode(chunk)
  File "/home/blackwithwhite/Work/ged-soa/apps/local/lib/python2.7/site-packages/tornado/escape.py", line 90, in json_encode
    return _json_encode(recursive_unicode(value)).replace("</", "<\\/")
  File "/usr/lib/python2.7/json/__init__.py", line 233, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python2.7/json/encoder.py", line 203, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python2.7/json/encoder.py", line 266, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python2.7/json/encoder.py", line 180, in default
    raise TypeError(repr(o) + " is not JSON serializable")
```

As fix i suggest to remove `custom_channels` key from dictionary.

Thanks!
