### PR TITLE
Add assertion to prevent closed channel transfer to spawned process

### DIFF
--- a/gaffer/process.py
+++ b/gaffer/process.py
@@ -396,6 +396,9 @@ class Process(object):
             self._stdio.append(stream.stdio)
         # create containers for custom channels.
         for channel in self.custom_channels:
+            assert not channel.closed, \
+                "Closed channel {0!r} can't be passed to process!" \
+                    .format(channel)
             self._stdio.append(pyuv.StdIO(stream=channel,
                 flags=pyuv.UV_INHERIT_STREAM))
 


### PR DESCRIPTION
Now, if i specify _custom_channels_ for _gaffer.process.Process_ i can receive something like that:

```
[1]    10182 segmentation fault (core dumped)  thriftserver

Program terminated with signal 11, Segmentation fault.
#0  0x00007f776f2b4c67 in uv__process_init_stdio (container=0x7f775c04fb70, 
    fds=0x7f775c062bd0, writable=1) at src/unix/process.c:146
```

In this request i add assertion to prevent closed channel passing to spawning process.
