### PR TITLE
Use kill method in stop

### DIFF
--- a/gaffer/process.py
+++ b/gaffer/process.py
@@ -692,7 +692,7 @@ class Process(object):
 
     def stop(self):
         """ stop the process """
-        self._process.kill(signal.SIGTERM)
+        self.kill(signal.SIGTERM)
 
     def kill(self, signum):
         """ send a signal to the process """


### PR DESCRIPTION
Exception `HandleClosedError` can happen in `gaffer.process.Process.stop` (for example, when method `stop` called twice). It will be safer to use method `kill` in `stop`. Or it will be better to generate some exception in this case?
