### PR TITLE
added gafferctl reference to command-line.rst

### DIFF
--- a/docs/command-line.rst
+++ b/docs/command-line.rst
@@ -32,3 +32,4 @@ processes, changes their configureation, get changes on the nodes in rt
 
    gaffer
    gafferd
+   gafferctl


### PR DESCRIPTION
The gafferctl tool was missing from the list of command line tools at the bottom, making the gafferctl page inaccessible from the command-line page. The tool has been added to the list of links.
