### PR TITLE
raw_input for username

### DIFF
--- a/gaffer/gafferd/main.py
+++ b/gaffer/gafferd/main.py
@@ -320,7 +320,7 @@ class Server(object):
 
             if not username:
                 while True:
-                    username = input("username: ").lower()
+                    username = raw_input("username: ").lower()
                     if username and username is not None:
                         if auth_mgr.has_user(username):
                             print("username %r already exists. " % username


### PR DESCRIPTION
Hi,
On creating a superuser, we don't expect the user to type 

> > "admin" 
> > but 
> > admin 
> > (without quotes). 

raw_input seems to be the good function.

Cheers
