### PR TITLE
shorter installation from git

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,8 +62,7 @@ recent version of distribute installed::
 
 To install from source, run the following command::
 
-    $ git clone https://github.com/benoitc/gaffer.git
-    $ cd gaffer && pip install -r requirements.txt
+    $ pip install git+https://github.com/benoitc/gaffer.git
 
 
 From pypi::


### PR DESCRIPTION
PRO: one line, installs gaffer in the process
CON: you won't have neither pytest, nor examples
