### PR TITLE
input/raw_input Python 2 compatibility

### DIFF
--- a/gaffer/cli/commands/base.py
+++ b/gaffer/cli/commands/base.py
@@ -9,6 +9,10 @@ import os
 import re
 import sys
 
+try:
+    input = raw_input
+except NameError:
+    pass
 
 KNOWN_COMMANDS = []
 def get_commands():

--- a/gaffer/cli/commands/login.py
+++ b/gaffer/cli/commands/login.py
@@ -6,6 +6,12 @@ try:
     import configparser
 except ImportError:
     import ConfigParser as configparser
+
+try:
+    input = raw_input
+except NameError:
+    pass
+
 from getpass import getpass
 import os
 import sys

--- a/gaffer/cli/commands/user_add.py
+++ b/gaffer/cli/commands/user_add.py
@@ -3,6 +3,11 @@
 # This file is part of gaffer. See the NOTICE for more information.
 from getpass import getpass
 
+try:
+    input = raw_input
+except NameError:
+    pass
+
 from ...gafferd.util import confirm
 from ...httpclient.base import GafferConflict
 from ...httpclient.users import Users

--- a/gaffer/cli/commands/user_setkey.py
+++ b/gaffer/cli/commands/user_setkey.py
@@ -4,6 +4,11 @@
 
 from getpass import getpass
 
+try:
+    input = raw_input
+except NameError:
+    pass
+
 from ...gafferd.util import confirm
 from ...httpclient.base import GafferNotFound
 from ...httpclient.users import Users

--- a/gaffer/gafferd/util.py
+++ b/gaffer/gafferd/util.py
@@ -2,6 +2,11 @@
 #
 # This file is part of gaffer. See the NOTICE for more information.
 
+try:
+    input = raw_input
+except NameError:
+    pass
+
 from importlib import import_module
 import os
 import sys


### PR DESCRIPTION
In Python 3 `raw_input()` has been renamed to `input()`. This means that when gaffer is used in Python 2, strings have to be entered with quotes. To correct this behaviour, I have aliased `input = raw_input`

I've corrected this in each file that uses `input`. Alternatively this could be put util.py, as suggested in benoitc/gaffer#32.
