### PR TITLE
Fix two, unrelated bugs

### DIFF
--- a/gaffer/process.py
+++ b/gaffer/process.py
@@ -617,7 +617,7 @@ class Process(object):
                 self._pprocess is not None):
 
             self._info.update({'os_pid': self.os_pid,
-                'create_time':self._pprocess.create_time})
+                'create_time':self._pprocess.create_time()})
 
         self._info['active'] = self._process.active
         return self._info

--- a/test/test_process.py
+++ b/test/test_process.py
@@ -298,6 +298,7 @@ def test_custom_channel():
     def stop(handle):
         channel.stop_read()
         p.stop()
+        for p in pipes: p.close()
 
     t = pyuv.Timer(loop)
     t.start(stop, 0.3, 0.0)


### PR DESCRIPTION
1. process would occasionally send create_time, the method, as the time, instead of calling it to get the actual time.  38fb907 fixes that.
2. a test left pipes open, which caused the test run to fail with an abort trap.  this should allow tests to run correctly now (tested on Python 3.4.3 and Python 2.7.9 with no failures on either).