### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,19 @@ failure, enabling fault tolerance and high availability.
 - Subscribe to process statistics per process or process templates and get them in quasi RT.
 - Procfile applications support but also JSON config support.
 - Supervisor-like features.
-- Fully evented. Use the libuv event loop using the [pyuv library](http://pyuv.readthedocs.org)
+- Fully evented. Use the libuv event loop using the [pyuv library](https://pyuv.readthedocs.io)
 - Flapping: handle cases where your processes crash too much
 - Easily extensible: add your own endpoint, create your client, embed gaffer in your application, ...
 - Compatible with python 2.7x, 3.x
 
 ## Documentation
 
-http://gaffer.readthedocs.org
+https://gaffer.readthedocs.io
 
 ## Getting Started
 
 
-http://gaffer.readthedocs.org/en/latest/getting-started.html
+https://gaffer.readthedocs.io/en/latest/getting-started.html
 
 ## Installation
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,7 +44,7 @@ Features
       support.
     - Supervisor-like features.
     - Fully evented. Use the libuv event loop using the
-      `pyuv library <http://pyuv.readthedocs.org>`_
+      `pyuv library <https://pyuv.readthedocs.io>`_
     - Flapping: handle cases where your processes crash too much
     - Easily extensible: add your own endpoint, create your client,
       embed gaffer in your application, ...

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -12,7 +12,7 @@ Design
 
 Gaffer is internally based on an event loop using the 
 `libuv <https://github.com/joyent/libuv/>`_ from Joyent via 
-the `pyuv binding <https://pyuv.readthedocs.org>`_
+the `pyuv binding <https://pyuv.readthedocs.io>`_
 
 All gaffer events are added to the loop and processes asynchronously which
 make it pretty performant for handling & controlling multiple processes.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.